### PR TITLE
Support for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^8.1",
         "filament/filament": "^3.0",
         "spatie/laravel-package-tools": "^1.15.0",
-        "illuminate/contracts": "^10.0"
+        "illuminate/contracts": "^10.0|^11.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
Added `...|^11.0` to the contracts dependency which makes it work in Laravel 11

`"illuminate/contracts": "^10.0|^11.0"`