### PR TITLE
fix added scroll space in when first tab is selected.

### DIFF
--- a/resources/views/forms/components/translate-tab.blade.php
+++ b/resources/views/forms/components/translate-tab.blade.php
@@ -8,7 +8,7 @@
         'mt-6' => ! $isContained,
     ]);
 
-    $inactiveTabClasses = 'invisible h-0 overflow-y-hidden p-0';
+    $inactiveTabClasses = 'invisible h-0 overflow-hidden p-0';
 
     $actions = $getActions();
     $hasActions = filled($actions);


### PR DESCRIPTION
This aligns the component with default filament tab
And fix an issue where the page would have an additional over-scroll space when first tab is selected.
![image](https://github.com/user-attachments/assets/0710bbd6-a689-4582-aa7f-c392f5786c6b)
