### PR TITLE
fix: close code fragment tag before Demo header

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ To publish the configuration file, use:
 
 ```bash
 php artisan vendor:publish --provider="SolutionForest\\FilamentTranslateField\\FilamentTranslateFieldServiceProvider" --tag="filament-translate-field-config"
-``
+```
 
 ## Example
 


### PR DESCRIPTION
Fix next typo

<img width="894" alt="image" src="https://github.com/user-attachments/assets/8ef4107e-d884-4ac8-8184-a865162a0290">
