### PR TITLE
fix: state path not applying to children schemas

### DIFF
--- a/src/Forms/Component/Translate.php
+++ b/src/Forms/Component/Translate.php
@@ -249,8 +249,6 @@ class Translate extends Component
 
     protected function prepareTranslateLocaleComponent(Component $component, string $locale): Component
     {
-
-
         $localeComponent = clone $component;
 
         if( method_exists($localeComponent,'getName')){
@@ -277,6 +275,15 @@ class Translate extends Component
                 // Spatie transltable field format
                 $localeComponent->name($component->getName().'.'.$locale);
                 $localeComponent->statePath($localeComponent->getName());
+            }
+        } else {
+            $childComponents = $localeComponent->getChildComponents();
+            if ($childComponents) {
+                $localeComponent->schema(
+                    collect($childComponents)
+                        ->map(fn ($childComponent) => $this->prepareTranslateLocaleComponent($childComponent, $locale))
+                        ->all()
+                );
             }
         }
 


### PR DESCRIPTION
fields that were declared as children of fieldset, section or other component wrappers were not getting translated. here is video of the bug:

https://github.com/user-attachments/assets/0093e75e-abaa-4281-b387-63495cf31929

as you can see title and subtitle are not changing their value when switching locale because they are under fieldset. same thing happens with section and other component wrappers.
this is after the fix: 

https://github.com/user-attachments/assets/9ec4ffca-9a8b-43f1-a729-2421c7f2ead1


to reproduce this issue i created sample laravel project which you can [view here](https://github.com/GigaGiorgadze/translate-children-issue)

to actually reproduce clone this repository.

clone forked version of package using command:
```bash
git clone https://github.com/GigaGiorgadze/filament-translate-field.git filament-translate-field
```

make sure to run this command in root of the laravel project and make sure that name is same.

after that just setup database, run migration, composer install, create filament user. login on /admin url and create or edit a post.

thank you :pray: 
