### PR TITLE
fix: replace getChildComponentContainers with getChildSchemas

### DIFF
--- a/src/Forms/Component/Translate.php
+++ b/src/Forms/Component/Translate.php
@@ -222,7 +222,7 @@ class Translate extends Component
 
             $queryStringTab = request()->query($this->getTabQueryStringKey());
 
-            $tabs = collect($this->getChildComponentContainers())
+            $tabs = collect($this->getChildSchemas())
                 ->map(fn (Schema $schema) => collect($schema->getComponents())->first() ?? null)
                 ->values();
 
@@ -252,7 +252,7 @@ class Translate extends Component
     /**
      * @return array<Schema>
      */
-    public function getChildComponentContainers(bool $withHidden = false): array
+    public function getChildSchemas(bool $withHidden = false): array
     {
         $containers = [];
 


### PR DESCRIPTION
https://github.com/filamentphp/filament/blob/1b9c20819ce8d951e0a9ad3a13d3574f28ca5324/packages/schemas/src/Components/Concerns/HasChildComponents.php#L110

`getChildComponentContainers` is marked as deprecated and somehow producing problems with handling `RichEditor`. 

This PR changes `getChildComponentContainers` to `getChildSchemas`.