### PR TITLE
Fix TypeError in tabs.js for non-scrollable Translate tabs

### DIFF
--- a/resources/views/forms/components/translate.blade.php
+++ b/resources/views/forms/components/translate.blade.php
@@ -24,6 +24,7 @@
         x-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('tabs', 'filament/schemas') }}"
         x-data="tabsSchemaComponent({
             activeTab: @js($activeTab),
+            isScrollable: @js(true),
             isTabPersistedInQueryString: @js($isTabPersistedInQueryString()),
             livewireId: @js($this->getId()),
             tab: @if ($isTabPersisted() && filled($persistenceKey = $getKey())) $persist(null).as('tabs-{{ $persistenceKey }}') @else @js(null) @endif,


### PR DESCRIPTION
## Problem

When using the Translate component on a Filament 5 page, the browser console throws:

```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'clientWidth')
    at Proxy.calculateDropdownIconWidth (tabs.js)
    at Proxy.updateTabsWithinDropdown (tabs.js)
```

## Root Cause

The `translate.blade.php` template loads Filament's `tabsSchemaComponent` Alpine component without passing `isScrollable`, which defaults to `false`. This triggers the non-scrollable dropdown overflow logic in `tabs.js`, which expects a dropdown trigger element (`.fi-tabs-item:last-child` containing a `.fi-icon`) to be present in the DOM.

However, the Translate component renders tabs using `<x-filament::tabs>` (the presentation component) which does **not** include the dropdown trigger markup that Filament 5's native `tabs.blade.php` schema component renders (lines 167-209). When `updateTabsWithinDropdown()` runs, `triggerEl.querySelector('.fi-icon')` returns `null`, causing the crash.

## Fix

Pass `isScrollable: true` to `tabsSchemaComponent` in the Alpine data. This skips the dropdown overflow logic entirely, which is appropriate since locale/translation tabs are always a small fixed set and don't need responsive overflow handling.